### PR TITLE
bugfix: specify the function signature for onPress in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { GestureResponderEvent } from 'react-native'
 
 interface IProps {
     switchOn: boolean;
-    onPress: func;
+    onPress: (event: GestureResponderEvent) => {};
     containerStyle?: object;
     circleStyle?: object;
     backgroundColorOn?: string;


### PR DESCRIPTION
TypeScript definitions require the function signature to be specified. This change specifies the function signature as compared to the output from react-native's onPress function signature