### PR TITLE
Changed componentWillReceiveProps for componentDidUpdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ class Item extends Component {
     leftContainerStyle: PropTypes.any,
   };
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.switchOn !== this.props.switchOn) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.switchOn !== this.props.switchOn) {
       this.runAnimation();
     }
   };
@@ -71,8 +71,8 @@ class Item extends Component {
   runAnimation = () => {
     // this.state.anim.setValue(0);
     const animValue: any = {
-      fromValue: this.props.switchOn ? 1 : 0,
-      toValue: this.props.switchOn ? 0 : 1,
+      fromValue: this.props.switchOn ? 0 : 1,
+      toValue: this.props.switchOn ? 1 : 0,
       duration: this.props.duration,
     };
     Animated.timing(this.state.animXValue, animValue).start();


### PR DESCRIPTION
I was using react-native-switch-toggle by dooboolab and encountered some warnings that popped out when rendering these buttons. I simply did some research on that warning and did as some other issues and stackoverflow posts recommended and removed the method componentWillRecieveProps and added my version of componentDidUpdate. I also changed some of the animation usage to make sense after the changes I had made.